### PR TITLE
Pin commonmark dependency to 0.5.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - commonmark
+    - commonmark<=0.5.4
     - docutils
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ about:
   home: https://github.com/rtfd/recommonmark
   license: MIT
   license_family: MIT
-  license_file: license.md
+  # license_file: license.md # Their license.md is not distributed in their pypi package.
   summary: 'A docutils-compatibility bridge to CommonMark.'
 
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - commonmark<=0.5.4
+    - commonmark <=0.5.4
     - docutils
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ about:
   home: https://github.com/rtfd/recommonmark
   license: MIT
   license_family: MIT
-#  license_file: LICENSE.md
+  license_file: license.md
   summary: 'A docutils-compatibility bridge to CommonMark.'
 
   description: |


### PR DESCRIPTION
See https://github.com/rtfd/recommonmark/commit/7ca5247b342e755ce5294d43b5fef68afd90028e

This depends on the commonmark feedstock building 0.5.4: conda-forge/commonmark-feedstock#6